### PR TITLE
Base image changed to node, because dockerfile/nodejs is redirecting …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Pull base image.
-FROM dockerfile/nodejs
+FROM node
 
 # Install Bower & Gulp
 RUN npm install -g bower gulp


### PR DESCRIPTION
…to library/node in docker hub registry.

I'm no docker expert, but from my limited point of view this is the simplest solution I've found.

Thanks.
